### PR TITLE
Update test lib, .gitignore, link, whitespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 # Don’t commit the following directories created by pub.
 build/
 packages/
+.pub/
 .buildlog
+.packages
+.project
 
 # Or the files created by dart2js.
 *.dart.js
@@ -9,6 +12,9 @@ packages/
 *.js_
 *.js.deps
 *.js.map
+
+# Directory created by dartdoc
+doc/api/
 
 # Include when developing application packages.
 pubspec.lock

--- a/lib/src/supports_color.dart
+++ b/lib/src/supports_color.dart
@@ -7,8 +7,8 @@ import 'dart:io';
 bool get supportsColor {
   if(_supportsColor == null) {
     _supportsColor = supportsColorTestable(
-        hasTerminal: stdout.hasTerminal, 
-        isWindows: Platform.isWindows, 
+        hasTerminal: stdout.hasTerminal,
+        isWindows: Platform.isWindows,
         env: Platform.environment);
   }
   return _supportsColor;
@@ -16,22 +16,22 @@ bool get supportsColor {
 bool _supportsColor;
 
 bool supportsColorTestable({
-    bool hasTerminal: true, 
-    bool isWindows: false, 
+    bool hasTerminal: true,
+    bool isWindows: false,
     Map<String, String> env: const {}}) {
-  
+
   var term = env['TERM'];
   bool supportsTerm() => term != null && term != 'dumb' && _termPattern.hasMatch(term);
-  
+
   if (isWindows) {
-    
+
     // Cygwin mintty terminal.
     // Ignore hasTerminal since it will always be false since mintty uses pipes.
     if (supportsTerm()) return true;
-    
+
     if (!hasTerminal) return false;
-    
-    // TODO: `return true` once http://dartbug.com/21337 is fixed.
+
+    // TODO: `return true` once https://github.com/dart-lang/sdk/issues/21337 is fixed.
     return false;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: supports_color
-version: 0.1.1
+version: 0.1.2
 author: Sean Eagan <seaneagan1@gmail.com>
 description: Detect whether the current terminal supports color.  This is a dart port of the https://www.npmjs.org/package/supports-color.
 homepage: https://github.com/seaneagan/supports_color
 dev_dependencies:
-  unittest: '>=0.11.0 <0.12.0'
+    test: '^0.12.6'

--- a/test/supports_color_test.dart
+++ b/test/supports_color_test.dart
@@ -1,8 +1,9 @@
 
 library supports_color.test;
 
+import 'package:test/test.dart';
+
 import 'package:supports_color/src/supports_color.dart';
-import 'package:unittest/unittest.dart';
 
 main() {
   group('supportsColor', () {


### PR DESCRIPTION
- Replace deprecated unittest package with the new test package.
- Update link. Fix whitespace.
- Update .gitignore.
- Bump version.
