### PR TITLE
Added support for Dart 2 SDK

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: supports_color
-version: 0.1.1
+version: 0.2.0
 author: Sean Eagan <seaneagan1@gmail.com>
 description: Detect whether the current terminal supports color.  This is a dart port of the https://www.npmjs.org/package/supports-color.
 homepage: https://github.com/seaneagan/supports_color

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,5 +3,9 @@ version: 0.1.1
 author: Sean Eagan <seaneagan1@gmail.com>
 description: Detect whether the current terminal supports color.  This is a dart port of the https://www.npmjs.org/package/supports-color.
 homepage: https://github.com/seaneagan/supports_color
+
+environment:
+  sdk: '>=2.0.0-dev.54.0 <3.0.0' # Defined by test package below.
+
 dev_dependencies:
-  unittest: '>=0.11.0 <0.12.0'
+  test: '^1.3.0'

--- a/test/supports_color_test.dart
+++ b/test/supports_color_test.dart
@@ -2,7 +2,7 @@
 library supports_color.test;
 
 import 'package:supports_color/src/supports_color.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 main() {
   group('supportsColor', () {


### PR DESCRIPTION
I updated the `pubspec.yaml` to version 0.2.0 to indicate this may be a breaking change because of the SDK constraint. The old `unittest` is deprecated and I updated the tests to the new `test` package of version 1.3.0.