### PR TITLE
fixes for dart 2 compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,5 +3,11 @@ version: 0.1.1
 author: Sean Eagan <seaneagan1@gmail.com>
 description: Detect whether the current terminal supports color.  This is a dart port of the https://www.npmjs.org/package/supports-color.
 homepage: https://github.com/seaneagan/supports_color
+
+environment:
+  sdk: '>=1.24.3<3.0.0'
+
 dev_dependencies:
-  unittest: '>=0.11.0 <0.12.0'
+  build_runner: ">=0.6.0 <1.0.0"
+  build_test: ">=0.9.0 <1.0.0"
+  test: ">=0.12.30 <2.0.0"

--- a/test/supports_color_test.dart
+++ b/test/supports_color_test.dart
@@ -1,8 +1,8 @@
-
+@TestOn('vm')
 library supports_color.test;
 
+import 'package:test/test.dart';
 import 'package:supports_color/src/supports_color.dart';
-import 'package:unittest/unittest.dart';
 
 main() {
   group('supportsColor', () {


### PR DESCRIPTION
# Summary
This package doesn't install under Dart 2 due to not having a dart sdk setting in pubspec.yaml. It also uses a discontinued dependency (unittest).

# Changes
- Set the allowed Dart SDK range in the pubspec.yaml. It is code compatible with dart 1 and dart 2, so allow both.
- remove the old unittest dependency. the test package provides everything that used to.
- Include build_runner and build_test for running tests under Dart 2
- Specify that the test is a VM test with `@TestOn('vm')`

# Testing
Verify that the dependencies solve and the tests pass using both Dart 1 and Dart 2.
dart1: `pub run test -p vm`
dart2: `pub run build_runner test -- -p vm`
